### PR TITLE
Support flat npm module layout

### DIFF
--- a/index.js
+++ b/index.js
@@ -246,7 +246,7 @@ const criticTrackChanges = text => text
   .replace(regex.critic.sub, '<span class="deletion">$1</span><span class="insertion">$2</span>')
 
 const pandocOptionsHTML = [
-  '--css', path.join(__dirname, 'node_modules/github-markdown-css/github-markdown.css'),
+  '--css', require.resolve('github-markdown-css'),
   '--css', path.join(__dirname, 'pandiff.css'),
   '--variable', 'include-before=<article class="markdown-body">',
   '--variable', 'include-after=</article>',


### PR DESCRIPTION
I get this message when running pandiff with the `-s` option:

```
/home/ptgolden/npm-local/node_modules/pandiff/node_modules/github-markdown-css/github-markdown.css: openBinaryFile: does not exist (No such file or directory)
```

Since npm3, it is no longer necessarily the case that the dependencies of an installed npm module will be located in the `node_modules` directory of that module. This commit uses `require.resolve` to find the location of the github-markdown-css file, rather than assuming its location in a nested `node_modules` folder.