### PR TITLE
Preserve custom styles and metadata in pandiff .docx output

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -44,6 +44,7 @@ const optionDefinitions: commandLineArgs.OptionDefinition[] = [
   {name: 'mathml', type: Boolean},
   {name: 'output', alias: 'o', type: File},
   {name: 'pdf-engine', type: String},
+  {name: 'metadata-file', type: File, multiple: true},
   {name: 'reference-doc', type: File, multiple: true},
   {name: 'reference-links', type: Boolean},
   {name: 'resource-path', type: Path},

--- a/src/index.ts
+++ b/src/index.ts
@@ -190,7 +190,6 @@ async function convert(source: string, opts: pandiff.Options = {}) {
     'lua-filter',
     'mathjax',
     'mathml',
-    'reference-doc',
     'resource-path'
   );
   args.push('--html-q-tags', '--mathjax');
@@ -371,6 +370,7 @@ async function postrender(text: string, opts: pandiff.Options = {}) {
     'highlight-style',
     'output',
     'pdf-engine',
+    'reference-doc',
     'resource-path',
     'standalone',
     'to'
@@ -422,6 +422,7 @@ namespace pandiff { // eslint-disable-line
     output?: File;
     'pdf-engine'?: string;
     'reference-links'?: boolean;
+    'reference-doc'?: File,
     'resource-path'?: Path;
     standalone?: boolean;
     threshold?: number;

--- a/src/index.ts
+++ b/src/index.ts
@@ -370,6 +370,7 @@ async function postrender(text: string, opts: pandiff.Options = {}) {
     'highlight-style',
     'output',
     'pdf-engine',
+    'metadata-file',
     'reference-doc',
     'resource-path',
     'standalone',
@@ -422,6 +423,7 @@ namespace pandiff { // eslint-disable-line
     output?: File;
     'pdf-engine'?: string;
     'reference-links'?: boolean;
+    'metadata-file'?: File,
     'reference-doc'?: File,
     'resource-path'?: Path;
     standalone?: boolean;


### PR DESCRIPTION
`--reference-doc` was accepted but in the wrong place: the argument must be given to the final invocation that creates the `.docx`.
Also metadata (title/subtitle) needs to be preserved somehow, so pass through `--metadata-file` if present.