### PR TITLE
add support for pandoc templates in final conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Usage: pandiff [OPTIONS] FILE1 FILE2
   -h, --help
       --highlight-style=STRING
       --lua-filter=FILE
+      --template=STRING
       --mathjax=BOOL
       --mathml=BOOL
   -o, --output=FILE

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -40,6 +40,7 @@ const optionDefinitions: commandLineArgs.OptionDefinition[] = [
   {name: 'help', alias: 'h', type: Boolean},
   {name: 'highlight-style', type: String},
   {name: 'lua-filter', type: File, multiple: true},
+  {name: 'template', type: String},
   {name: 'mathjax', type: Boolean},
   {name: 'mathml', type: Boolean},
   {name: 'output', alias: 'o', type: File},

--- a/src/index.ts
+++ b/src/index.ts
@@ -419,6 +419,7 @@ async function postrender(text: string, opts: pandiff.Options = {}) {
     opts,
     'highlight-style',
     'output',
+    'template',
     'pdf-engine',
     'metadata-file',
     'reference-doc',
@@ -470,6 +471,7 @@ namespace pandiff { // eslint-disable-line
     help?: boolean;
     'highlight-style'?: string;
     'lua-filter'?: File[];
+    template?: string;
     output?: File;
     'pdf-engine'?: string;
     'reference-links'?: boolean;


### PR DESCRIPTION
Does as the title says. I use the eisvogel template for my final document. 

I want to use it inside a ci/cd to dynamically calculate the changes and create the diff view. I think that pandiff is perfect for that. However, I would like the diff-view to use the same template as the final document. Therefore, the template support for the would be helpful.

If there are any issues with my changes, please say so, and I will improve them.
Please let me know what you think of this ^^